### PR TITLE
Leave file path to caller

### DIFF
--- a/LolayQueueManager.m
+++ b/LolayQueueManager.m
@@ -36,8 +36,7 @@
 	self = [super init];
 	
 	if (self) {
-		NSString* filePath = [[NSBundle bundleForClass:[self class]] pathForResource:pathForResource ofType:@"plist"];
-		NSArray* configQueues = [NSArray arrayWithContentsOfFile:filePath];
+		NSArray* configQueues = [NSArray arrayWithContentsOfFile:pathForResource];
 		
 		self.queues = [NSMutableDictionary dictionaryWithCapacity:configQueues.count];
 		


### PR DESCRIPTION
The caller should be allowed to specify a complete file path.
